### PR TITLE
Fetch all players at once and add caching

### DIFF
--- a/v0.0.1/VERGE-Browser/preload.js
+++ b/v0.0.1/VERGE-Browser/preload.js
@@ -149,12 +149,12 @@ window.addEventListener('load', function () {
 				// console.log(mainUserMatchHistory);
 				// console.log(mainUserOpponents);
 
-				var mainUserMatchHistoryData = [];
+				var mainUserMatchHistoryData = await Promise.all(mainUserOpponents.map((user) => getData("users/" + user)));
 
-				for await (let user of mainUserOpponents) {
-					let data = await getData("users/" + user);
-					mainUserMatchHistoryData.push(data);
-				}
+				// for await (let user of mainUserOpponents) {
+				// 	let data = await getData("users/" + user);
+				// 	mainUserMatchHistoryData.push(data);
+				// }
 				// console.log(mainUserMatchHistoryData);
 
 				// console.log("User data fetched in " + (Date.now() - tStart) / 1000 + " seconds!")


### PR DESCRIPTION
This change makes the extension fetch all users at once instead of synchronously and adds caching to all requests sent which speeds it up

I've only updated the browser version as I'm not sure how to build the desktop versions